### PR TITLE
chore: auto-merge minor dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-pr.yml
+++ b/.github/workflows/dependabot-auto-pr.yml
@@ -1,0 +1,39 @@
+name: chore
+
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Require status checks to pass before merging for the target branch for Dependabot pull requests.
+  # This job should only be on projects with comprehensive testing.
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == github.event.pull_request.head.repo.full_name
+    steps:
+
+      - name: "🤖 Dependabot metadata"
+        id: metadata
+        uses: dependabot/fetch-metadata@v2.3.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "🤖 Auto-merge Dependabot PRs for semver MINOR updates"
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
+        run: gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: "🤖 Auto-merge Dependabot PRs for semver PATCH updates"
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This PR will auto-merge dependabot PRs that are

- minor version bumps
- path version bumps

It will NOT auto-merge MAJOR version bumps; which should be manually reviewed due to break changes.